### PR TITLE
optimize: optimize SeataServer raft node update procedure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.21 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/controllers/service.go
+++ b/controllers/service.go
@@ -30,7 +30,6 @@ func initService(s *seatav1alpha1.SeataServer) *apiv1.Service {
 			Labels:    makeLabels(s.Name),
 		},
 	}
-	updateService(service, s)
 	return service
 }
 


### PR DESCRIPTION
## Background
The current architecture for scaling SeataServer involves updating raft nodes through access to the `/metadata/v1/changeCluster` endpoint. However, when accessing nodes one by one during the scaling process, there is a lack of proper health status checks. This can lead to scenarios where HTTP requests are sent to nodes that have not successfully started. Additionally, the existing implementation does not include the necessary login and token retrieval steps.

## Changes Made
- Added health status checks before sending HTTP requests to individual nodes during the scaling process.
- Implemented login and token retrieval operations to ensure proper authentication during the update of raft nodes.
