### PR TITLE
feature: enable debugging locally without building images

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Associated Projects:
 
 ### Usage
 
-To experience deploying Seata Server using the Operator method, follow these steps:
+To deploy Seata Server using the Operator method, follow these steps:
 
 1. Clone this repository:
 
@@ -20,28 +20,13 @@ To experience deploying Seata Server using the Operator method, follow these ste
    git clone https://github.com/apache/incubator-seata-k8s.git
    ```
 
-2. (Optional) Build and publish the controller image to a private registry:
-
-   > This step can be skipped, the operator use apache/seata-controller:latest as controller image by default.
-
-   ```shell
-   IMG=${IMAGE-TO-PUSH} make docker-build docker-push
-   ```
-
-   If you are using minikube for testing, you can skip the above publishing process with the following command:
-
-   ```shell
-   eval $(minikube docker-env)
-   IMG=${IMAGE-TO-PUSH} make docker-build
-   ```
-
-3. Deploy Controller, CRD, RBAC, and other resources to the Kubernetes cluster:
+2. Deploy Controller, CRD, RBAC, and other resources to the Kubernetes cluster:
 
    ```shell
    make deploy
    kubectl get deployment -n seata-k8s-controller-manager  # check if exists
    ```
-
+   
 4. You can now deploy your CR to the cluster. An example can be found here [seata-server-cluster.yaml](deploy/seata-server-cluster.yaml):
 
    ```yaml
@@ -97,6 +82,44 @@ For CRD details, you can visit [operator.seata.apache.org_seataservers.yaml](con
        console.user.password: seata
    ```
 
+
+
+### For Developer
+
+To debug this operator locally, we suggest you use a test k8s environment like minikube.
+
+1. Method 1. Modify code and build the controller image:
+
+   Assume you are using minikube for testing,
+
+   ```shell
+   eval $(minikube docker-env)
+   make docker-build deploy
+   ```
+
+2. Method 2. Locally debug without building images
+
+   You need to use telepresence to proxy traffic to the k8s cluster, see [telepresence tutorial](https://www.telepresence.io/docs/latest/quick-start/) to install its cli tool and [traffic manager](https://www.getambassador.io/docs/telepresence/latest/install/manager#install-the-traffic-manager). After installing telepresence, you can connect to minikube by following commands:
+
+   ```shell
+   telepresence connect
+   # Check if traffic manager connected
+   telepresence status
+   ```
+
+   By executing above commands, you can use in-cluster DNS resolution and proxy your requests to the cluster. And then you can use IDE to run or debug locally:
+
+   ```shell
+   # Make sure generate proper resources first
+   make manifests generate fmt vet
+   
+   go run .
+   # Or you can use IDE to run locally instead
+   ```
+
+   
+
+
 ## Method 2: Example without Using Operator
 
 Due to certain reasons, Seata Docker images currently do not support external container calls. Therefore, the example projects should also be kept in link mode with the Seata image inside the container.
@@ -137,3 +160,6 @@ curl -H "Content-Type: application/json" -X POST --data "{\"userId\":\"1\",\"com
 # Business service - Client Seata version too low
 curl -H "Content-Type: application/json" -X POST --data "{\"userId\":\"1\",\"commodityCode\":\"C201901140001\",\"count\":10,\"amount\":100}" cluster-ip:8104/business/dubbo/buy
 ```
+
+
+

--- a/README.zh.md
+++ b/README.zh.md
@@ -24,21 +24,6 @@ https://github.com/seata/seata-docker
    git clone https://github.com/apache/incubator-seata-k8s.git
    ```
 
-2. (可选) 发布 controller 镜像到私有 Registry
-
-   > 这一步可以跳过，本 Operator 默认使用 `apache/seata-controller:latest` 作为 controller 镜像
-
-   ```shell
-   IMG=${IMAGE-TO-PUSH} make docker-build docker-push
-   ```
-
-   如果你正在使用 minikube 进行测试，可以通过以下命令免去上述的发布流程
-
-   ```shell
-   eval $(minikube docker-env)
-   IMG=${IMAGE-TO-PUSH} make docker-build
-   ```
-
 3. 部署 Controller, CRD, RBAC 等资源到 Kubernetes 集群
 
    ```shell
@@ -104,7 +89,38 @@ https://github.com/seata/seata-docker
    
    
 
+### For Developer
 
+要在本地调试此 Operator，我们建议您使用像 Minikube 这样的测试 k8s 环境。
+
+1. 方法 1：修改代码并构建控制器镜像：
+
+   假设您正在使用 Minikube 进行测试，
+
+   ```shell
+   eval $(minikube docker-env)
+   make docker-build deploy
+   ```
+
+2. 方法 2：不构建镜像进行本地调试
+
+   您需要使用 Telepresence 将流量代理到 k8s 集群，参见[Telepresence 教程](https://www.telepresence.io/docs/latest/quick-start/)来安装其 CLI 工具和[Traffic Manager](https://www.getambassador.io/docs/telepresence/latest/install/manager#install-the-traffic-manager)。安装 Telepresence 后，可以按照以下命令连接到 Minikube：
+
+   ```shell
+   telepresence connect
+   # 检查流量管理器是否连接
+   telepresence status
+   ```
+
+   通过执行上述命令，您可以使用集群内 DNS 解析并将请求代理到集群。然后您可以使用 IDE 在本地运行或调试：
+
+   ```shell
+   # 首先确保生成适当的资源
+   make manifests generate fmt vet
+   
+   go run .
+   # 或者您也可以使用 IDE 在本地运行
+   ```
 
 ## 方式二: 不使用 Operator 的示例
 

--- a/controllers/seataserver_controller.go
+++ b/controllers/seataserver_controller.go
@@ -119,7 +119,7 @@ func (r *SeataServerReconciler) reconcileHeadlessService(ctx context.Context, s 
 	} else if err != nil {
 		return err
 	} else {
-		logger.Info(fmt.Sprintf("Updating existing SeataServer StatefulSet {%s:%s}",
+		logger.Info(fmt.Sprintf("Updating existing SeataServer Service {%s:%s}",
 			foundSvc.Namespace, foundSvc.Name))
 
 		seata.SyncService(foundSvc, svc)

--- a/deploy/seata-server-cluster.yaml
+++ b/deploy/seata-server-cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceName: seata-server-cluster
   replicas: 2
-  image: seataio/seata-server:2.0.0
+  image: seataio/seata-server:latest
   store:
     resources:
       requests:

--- a/pkg/seata/synchronizers.go
+++ b/pkg/seata/synchronizers.go
@@ -35,7 +35,7 @@ type rspData struct {
 
 func changeCluster(s *seatav1alpha1.SeataServer, i int32) error {
 	client := http.Client{}
-	host := fmt.Sprintf("%s-%d.%s.%s.svc:%d", s.Name, i, s.Spec.ServiceName, s.Namespace, s.Spec.Ports.ConsolePort)
+	host := fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local:%d", s.Name, i, s.Spec.ServiceName, s.Namespace, s.Spec.Ports.ConsolePort)
 	username, ok := s.Spec.Env["console.user.username"]
 	if !ok {
 		username = "seata"


### PR DESCRIPTION
### What this PR does?
1. Modify the statefulset pod qualified name from `seata-server-0.seata-server-cluster.default.svc` to `seata-server-0.seata-server-cluster.default.svc.cluster.local` (the former can not be resolved using telepresence).
2. Add developer usage in README

### Usage
See README.md or README.zh.md.

To debug this operator locally, we suggest you use a test k8s environment like minikube.

1. Method 1. Modify code and build the controller image:

   Assume you are using minikube for testing,

   ```shell
   eval $(minikube docker-env)
   make docker-build deploy
   ```

3. Method 2. Locally debug without building images

   You need to use telepresence to proxy traffic to the k8s cluster, see [telepresence tutorial](https://www.telepresence.io/docs/latest/quick-start/) to install its cli tool and [traffic manager](https://www.getambassador.io/docs/telepresence/latest/install/manager#install-the-traffic-manager). After installing telepresence, you can connect to minikube by following commands:

   ```shell
   telepresence connect
   # Check if traffic manager connected
   telepresence status
   ```

   By executing above commands, you can use in-cluster DNS resolution and proxy your requests to the cluster. And then you can use IDE to run or debug locally:

   ```shell
   # Make sure generate proper resources first
   make manifests generate fmt vet
   
   go run .
   # Or you can use IDE to run locally instead
   ```
